### PR TITLE
Make listen address configurable and fix default

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -58,11 +58,12 @@ app.js
 You can also specify these values using environment variables.
 Refer to the table to see which environment variables can be used.
 
-|   *Value*   |   *Environment Variable*    |
-|:------------|:--------------------------: |
-|Secret       |STAFFBASE_SSO_SECRET         |
-|Audience     |STAFFBASE_SSO_AUDIENCE       |
-|Server Port  |PORT                         |
+|   *Value*     |   *Environment Variable*    |           *Default if not set*           |
+|:--------------|:--------------------------: |:----------------------------------------:|
+|Secret         |STAFFBASE_SSO_SECRET         | *(empty)*                                |
+|Audience       |STAFFBASE_SSO_AUDIENCE       | *(empty)*                                |
+|Server Port    |PORT                         | 3000                                     |
+|Server Address |ADDRESS                      | *(empty, listening on all IP addresses)* |
 
 ## Running the server
 _create-staffbase-plugin_ installs the project dependencies for you.

--- a/scaffoldTpl/bin/www
+++ b/scaffoldTpl/bin/www
@@ -9,11 +9,13 @@ var debug = require('debug')('ssosampleserver:server');
 var http = require('http');
 
 /**
- * Get port from environment and store in Express.
+ * Get port and listen address from environment and store in Express.
  */
 
 var port = normalizePort(process.env.PORT || '3000');
+var address = process.env.ADDRESS || '';
 app.set('port', port);
+app.set('address', port);
 
 /**
  * Create HTTP server.
@@ -22,10 +24,10 @@ app.set('port', port);
 var server = http.createServer(app);
 
 /**
- * Listen on provided port, on all network interfaces.
+ * Listen on provided port and network address.
  */
 
-server.listen(port, '127.0.0.1');
+server.listen(port, address);
 server.on('error', onError);
 server.on('listening', onListening);
 


### PR DESCRIPTION
This should solve issue #46 

- server address can be configured using environment variable address
- default server address is empty to listen on all IP addresses (like the comment suggests)
- application should now work in Heroku and Cloud Foundry
