### PR TITLE
chore(release): bump @staffbase/staffbase-plugin-sdk to 1.3.8 and release 1.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staffbase/create-staffbase-plugin",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "license": "MIT",
   "bin": {
     "create-staffbase-plugin": "csss.js"

--- a/scaffoldTpl/package.json
+++ b/scaffoldTpl/package.json
@@ -6,7 +6,7 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
-    "@staffbase/staffbase-plugin-sdk": "^1.3.1",
+    "@staffbase/staffbase-plugin-sdk": "^1.3.8",
     "cookie-parser": "^1.4.7",
     "debug": "^4.4.3",
     "express": "^5.2.1",


### PR DESCRIPTION
## Summary

- Bumps `@staffbase/staffbase-plugin-sdk` in `scaffoldTpl/package.json` from `^1.3.1` to `^1.3.8`
- Bumps package version to `1.0.15`
- Release notes: https://github.com/Staffbase/plugins-sdk-nodejs/releases/tag/1.3.8

## After merge

Create a GitHub Release with tag `v1.0.15` to trigger the NPM publish workflow.

## Test plan

- [x] `yarn test` passes (2/2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)