### PR TITLE
fix(ci): use App Client ID for gha-workflows v14 auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,5 +6,5 @@ jobs:
   dependabot:
     uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@v14.0.1
     secrets:
-      app_id: ${{ vars.STAFFBASE_ACTIONS_APP_ID }}
+      client_id: ${{ vars.STAFFBASE_ACTIONS_CLIENT_ID }}
       private_key: ${{ secrets.STAFFBASE_ACTIONS_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

The `Enable Dependabot Auto-Merge` workflow fails with `startup_failure` ("invalid workflow file"). Root cause is **not** an expired App ID/secret value — it's an undeclared/missing required secret name.

`Staffbase/gha-workflows` **v14** switched GitHub App authentication from **App ID** to **App Client ID**. `template_automerge_dependabot.yml` now declares `client_id` (required) instead of `app_id`. The caller still passed `app_id` → GitHub rejects the workflow before any step runs.

## Fix

Map the App Client ID org variable `STAFFBASE_ACTIONS_CLIENT_ID` to the template's `client_id` secret. `STAFFBASE_ACTIONS_PRIVATE_KEY` is unchanged. `publish-npm.yml` is unaffected (no App auth).

Reference: `STAFFBASE_ACTIONS_CLIENT_ID` org variable added in Staffbase/infrastructure (2026-06-05); same pattern already used by keytool-service, customer-control, wams. Companion fixes: cc-saml-test-service-provider#139, cc-custom-plugin-example#540.

Co-authored-by: GitHub Copilot <copilot@noreply.github.com>