### PR TITLE
chore(release): bump version to 1.0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staffbase/create-staffbase-plugin",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "license": "MIT",
   "bin": {
     "create-staffbase-plugin": "csss.js"


### PR DESCRIPTION
## Problem

The `v1.0.16` release failed to publish to npm:

```
npm error You cannot publish over the previously published versions: 1.0.15.
```

The `v1.0.16` tag/release was cut, but `package.json` was never bumped — it still read `1.0.15`, which is already on npm. So `npm publish` refused to overwrite it.

## Fix

Bump `package.json` to **1.0.17**. `1.0.16` was never published to npm, but versions/tags are immutable, so we move forward to `1.0.17` rather than rewriting the existing `v1.0.16` tag and release.

## Follow-up after merge

Cut a fresh `v1.0.17` release (the `Publish to NPM Registry` workflow triggers on `release: created`) to publish to npm.

Co-authored-by: GitHub Copilot <copilot@noreply.github.com>