### PR TITLE
chore(ci): bump automerge_dependabot to v15.0.0

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   dependabot:
-    uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@v14.1.0
+    uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@v15.0.0
     secrets:
       client_id: ${{ vars.STAFFBASE_ACTIONS_CLIENT_ID }}
       private_key: ${{ secrets.STAFFBASE_ACTIONS_PRIVATE_KEY }}


### PR DESCRIPTION
bumps gha-workflows automerge_dependabot ref v14.1.0 -> v15.0.0. tag verified to exist.

client_id/vars.STAFFBASE_ACTIONS_CLIENT_ID already correct, no change needed.

checked scaffoldTpl/ (generator's plugin template) - no workflow files or gha-workflows/app_id refs there, so no generated-plugin migration needed.