### PR TITLE
chore: align dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "08:00"
       timezone: "Europe/Berlin"
+      day: monday
     cooldown:
       default-days: 7
     target-branch: "main"
@@ -23,13 +24,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
-
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "08:00"
       timezone: "Europe/Berlin"
+      day: monday
     cooldown:
       default-days: 7
     target-branch: "main"


### PR DESCRIPTION
- What changed: set Dependabot schedules to weekly on monday.
- Why: align cadence across CC team-owned repos.
- Validation: reviewed .github/dependabot.yml changes only.