### PR TITLE
chore(cc-tech): update CODEOWNERS slug cs-tech → cc-tech

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @Staffbase/cs-tech
+*   @Staffbase/cc-tech


### PR DESCRIPTION
Slug consolidation `cs-tech` → `cc-tech` (CC Tech governance, Phase 3). The CC Tech team handle was renamed; this updates the last `@Staffbase/cs-tech` reference(s) in `.github/CODEOWNERS` to `@Staffbase/cc-tech`.

**How to review:** the diff should change only the team handle — no other owners or lines touched. GitHub keeps the old slug as a redirect, so reviews/alerts keep working regardless; this just removes the stale reference. No functional change.

This repo is CC Tech-owned, so a `@Staffbase/cc-tech` reviewer can approve.